### PR TITLE
Add keys to strength workout list table components

### DIFF
--- a/workout-stats-frontend/src/components/StrengthWorkoutList/StrengthWorkoutList.tsx
+++ b/workout-stats-frontend/src/components/StrengthWorkoutList/StrengthWorkoutList.tsx
@@ -27,6 +27,7 @@ export function StrengthWorkoutList({ workouts }: StrengthWorkoutListProps) {
           {formatDuration(w.duration)}
         </div>
         <WSTable
+          key={`stregnth-list-table-full-${w.sourceWorkoutId}`}
           headers={["Exercise", "Weight", "Reps", "Time"]}
           data={(w.exerciseSets || []).map((es) => [
             es.exercise.displayName,
@@ -74,6 +75,7 @@ export function StrengthWorkoutList({ workouts }: StrengthWorkoutListProps) {
             {formatDuration(w.duration)}
           </div>
           <WSTable
+            key={`stregnth-list-table-condensed-${w.sourceWorkoutId}`}
             headers={["Exercise", "Max Weight", "Sets", "Total Reps"]}
             data={condensedArr.map((ced) => [
               ced.exerciseName,


### PR DESCRIPTION
The lack of keys confused React and led to some unexpected behaviour (table headings sometimes not changing properly when switching between condensed and full view).