### PR TITLE
Use workout time when computing latest exercise date

### DIFF
--- a/workout-stats-frontend/src/components/ExercisesSummary/ExercisesSummary.tsx
+++ b/workout-stats-frontend/src/components/ExercisesSummary/ExercisesSummary.tsx
@@ -67,7 +67,7 @@ export function ExercisesSummary() {
 
   const getLatestDate = (key: string): Date => {
     return setsByExercise[key]
-      .map((es) => es.startTime)
+      .map((es) => es.workoutStartTime)
       .reduce((d1, d2) => (d1 > d2 ? d1 : d2));
   };
 


### PR DESCRIPTION
The exercise start time can sometimes be not present. This ends up as an Invalid Date object and that somehow gets promoted as the largest (latest) date, which then can't be formatted properly for displaying and causes errors. This should fix that as workout start time should always be present.